### PR TITLE
feat: add symlinks for cosmic apps

### DIFF
--- a/pixora/scalable/apps/com.system76.CosmicEdit.svg
+++ b/pixora/scalable/apps/com.system76.CosmicEdit.svg
@@ -1,0 +1,1 @@
+accessories-text-editor.svg

--- a/pixora/scalable/apps/com.system76.CosmicFiles.svg
+++ b/pixora/scalable/apps/com.system76.CosmicFiles.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/pixora/scalable/apps/com.system76.CosmicSettings.svg
+++ b/pixora/scalable/apps/com.system76.CosmicSettings.svg
@@ -1,0 +1,1 @@
+utilities-tweak-tool.svg

--- a/pixora/scalable/apps/com.system76.CosmicStore.svg
+++ b/pixora/scalable/apps/com.system76.CosmicStore.svg
@@ -1,0 +1,1 @@
+software-store.svg

--- a/pixora/scalable/apps/com.system76.CosmicTerm.svg
+++ b/pixora/scalable/apps/com.system76.CosmicTerm.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg


### PR DESCRIPTION
I have added symlinks for the Cosmic DE for the following Applications:
- COSMIC Files
- COSMIC Settings
- COSMIC Store
- COSMIC Terminal
- COSMIC Text Editor

There also exists COSMIC Screenshot and COSMIC Media Player, but I did not see any appropriate icons for those.